### PR TITLE
Add support for loading ELF files and added a few opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ buildtest:
 	#i386-elf-gcc -T linker.ld -o testos.bin -ffreestanding -O2 -nostdlib testos.o -lgcc -Wl,--gc-sections $(testos_CFLAGS) -dead_strip
 	yasm -o testbench/test.o testbench/test.asm -f elf32
 	i386-elf-gcc -T testbench/linker.ld -o test.elf -ffreestanding -nostdlib testbench/test.o -Wl,--gc-sections $(testos_CFLAGS) -dead_strip -Xlinker -Map=test.elf.map -Xlinker -n
-	strip -s -S test.elf
+	#strip -s -S test.elf
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 #This file is part of the x86Lib project.
 
 
-HDRS =  include/config.h include/opcode_def.h include/x86lib.h include/x86lib_internal.h
+HDRS =  include/config.h include/opcode_def.h include/x86lib.h include/x86lib_internal.h testbench/elf.h
 CXX ?= g++
 AR ?= ar
 
@@ -41,7 +41,7 @@ CXX_VM_SRC = vm/x86lib.cpp vm/modrm.cpp vm/device_manager.cpp vm/cpu_helpers.cpp
 
 CXX_VM_OBJS = $(subst .cpp,.o,$(CXX_VM_SRC))
 
-CXX_TESTBENCH_SRC = testbench/testbench.cpp
+CXX_TESTBENCH_SRC = testbench/testbench.cpp testbench/elfloader.cpp
 
 CXX_TESTBENCH_OBJS = $(subst .cpp,.o,$(CXX_TESTBENCH_SRC))
 
@@ -74,7 +74,7 @@ clean:
 	rm -f $(CXX_VM_OBJS) $(OUTPUTS) $(CXX_TESTBENCH_OBJS)
 
 buildtest:
-	i386-elf-gcc -c testos.c -o testos.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra $(testos_CFLAGS)
-	i386-elf-gcc -T linker.ld -o testos.bin -ffreestanding -O2 -nostdlib testos.o -lgcc -Wl,--gc-sections $(testos_CFLAGS) -dead_strip
-	yasm -o testasm.bin testasm.asm
+	#i386-elf-gcc -c testos.c -o testos.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra $(testos_CFLAGS)
+	#i386-elf-gcc -T linker.ld -o testos.bin -ffreestanding -O2 -nostdlib testos.o -lgcc -Wl,--gc-sections $(testos_CFLAGS) -dead_strip
+	yasm -o test.elf testbench/test.asm -f elf32
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ AR ?= ar
 
 
 TEST_CC ?= i386-elf-gcc
-TEST_CFLAGS ?= -fdata-sections -ffunction-sections
+TEST_CFLAGS ?= -Os -nostartfiles -nodefaultlibs -Wl,-z,norelro -Wl,--build-id=none -static
 
 
 CXX_VM_SRC = vm/x86lib.cpp vm/modrm.cpp vm/device_manager.cpp vm/cpu_helpers.cpp vm/ops/strings.cpp vm/ops/store.cpp vm/ops/maths.cpp \
@@ -76,5 +76,8 @@ clean:
 buildtest:
 	#i386-elf-gcc -c testos.c -o testos.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra $(testos_CFLAGS)
 	#i386-elf-gcc -T linker.ld -o testos.bin -ffreestanding -O2 -nostdlib testos.o -lgcc -Wl,--gc-sections $(testos_CFLAGS) -dead_strip
-	yasm -o test.elf testbench/test.asm -f elf32
+	yasm -o testbench/test.o testbench/test.asm -f elf32
+	i386-elf-gcc -T testbench/linker.ld -o test.elf -ffreestanding -nostdlib testbench/test.o -Wl,--gc-sections $(testos_CFLAGS) -dead_strip -Xlinker -Map=test.elf.map -Xlinker -n
+	strip -s -S test.elf
+
 

--- a/include/opcode_def.h
+++ b/include/opcode_def.h
@@ -277,6 +277,8 @@ void op_stosb();
 void op_stosW();
 void op_wait();
 void op_xlatb();
+void op_leave();
+void op_movsx_rW_rm8();
 
 void op_in_al_dx();
 void op_in_axW_dx();

--- a/include/x86lib.h
+++ b/include/x86lib.h
@@ -533,6 +533,9 @@ class x86CPU{
     void WriteMemory(uint32_t address, uint32_t size, void* buffer);
 
 	void Stop(){DoStop=true;}
+    uint32_t GetLocation(){
+        return eip;
+    }
 
     //provided mainly for slightly easier debugging
     uint8_t ReadMachineByte(uint32_t address){

--- a/testbench/elf.h
+++ b/testbench/elf.h
@@ -1,0 +1,167 @@
+#ifndef ELF_H
+#define ELF_H
+
+# include <stdint.h>
+ 
+typedef uint16_t Elf32_Half;    // Unsigned half int
+typedef uint32_t Elf32_Off; // Unsigned offset
+typedef uint32_t Elf32_Addr;    // Unsigned address
+typedef uint32_t Elf32_Word;    // Unsigned int
+typedef int32_t  Elf32_Sword;   // Signed int
+
+# define ELF_NIDENT 16
+ 
+typedef struct
+{
+  unsigned char e_ident[ELF_NIDENT]; /* Magic number and other info */
+  Elf32_Half    e_type;         /* Object file type */
+  Elf32_Half    e_machine;      /* Architecture */
+  Elf32_Word    e_version;      /* Object file version */
+  Elf32_Addr    e_entry;        /* Entry point virtual address */
+  Elf32_Off e_phoff;        /* Program header table file offset */
+  Elf32_Off e_shoff;        /* Section header table file offset */
+  Elf32_Word    e_flags;        /* Processor-specific flags */
+  Elf32_Half    e_ehsize;       /* ELF header size in bytes */
+  Elf32_Half    e_phentsize;        /* Program header table entry size */
+  Elf32_Half    e_phnum;        /* Program header table entry count */
+  Elf32_Half    e_shentsize;        /* Section header table entry size */
+  Elf32_Half    e_shnum;        /* Section header table entry count */
+  Elf32_Half    e_shstrndx;     /* Section header string table index */
+} Elf32_Ehdr;
+
+
+enum Elf_Ident {
+    EI_MAG0     = 0, // 0x7F
+    EI_MAG1     = 1, // 'E'
+    EI_MAG2     = 2, // 'L'
+    EI_MAG3     = 3, // 'F'
+    EI_CLASS    = 4, // Architecture (32/64)
+    EI_DATA     = 5, // Byte Order
+    EI_VERSION  = 6, // ELF Version
+    EI_OSABI    = 7, // OS Specific
+    EI_ABIVERSION   = 8, // OS Specific
+    EI_PAD      = 9  // Padding
+};
+ 
+# define ELFMAG0    0x7F // e_ident[EI_MAG0]
+# define ELFMAG1    'E'  // e_ident[EI_MAG1]
+# define ELFMAG2    'L'  // e_ident[EI_MAG2]
+# define ELFMAG3    'F'  // e_ident[EI_MAG3]
+ 
+# define ELFDATA2LSB    (1)  // Little Endian
+# define ELFCLASS32 (1)  // 32-bit Architecture
+
+enum Elf_Type {
+    ET_NONE     = 0, // Unkown Type
+    ET_REL      = 1, // Relocatable File
+    ET_EXEC     = 2  // Executable File
+};
+ 
+# define EM_386     (3)  // x86 Machine Type
+# define EV_CURRENT (1)  // ELF Current Version
+
+
+/* Section header.  */
+
+typedef struct
+{
+  Elf32_Word    sh_name;        /* Section name (string tbl index) */
+  Elf32_Word    sh_type;        /* Section type */
+  Elf32_Word    sh_flags;       /* Section flags */
+  Elf32_Addr    sh_addr;        /* Section virtual addr at execution */
+  Elf32_Off sh_offset;      /* Section file offset */
+  Elf32_Word    sh_size;        /* Section size in bytes */
+  Elf32_Word    sh_link;        /* Link to another section */
+  Elf32_Word    sh_info;        /* Additional section information */
+  Elf32_Word    sh_addralign;       /* Section alignment */
+  Elf32_Word    sh_entsize;     /* Entry size if section holds table */
+} Elf32_Shdr;
+
+#define SHN_UNDEF   0       /* Undefined section */
+#define SHN_LORESERVE   0xff00      /* Start of reserved indices */
+#define SHN_LOPROC  0xff00      /* Start of processor-specific */
+#define SHN_BEFORE  0xff00      /* Order section before all others
+                       (Solaris).  */
+#define SHN_AFTER   0xff01      /* Order section after all others
+                       (Solaris).  */
+#define SHN_HIPROC  0xff1f      /* End of processor-specific */
+#define SHN_LOOS    0xff20      /* Start of OS-specific */
+#define SHN_HIOS    0xff3f      /* End of OS-specific */
+#define SHN_ABS     0xfff1      /* Associated symbol is absolute */
+#define SHN_COMMON  0xfff2      /* Associated symbol is common */
+#define SHN_XINDEX  0xffff      /* Index is in extra table.  */
+#define SHN_HIRESERVE   0xffff      /* End of reserved indices */
+
+/* Legal values for sh_type (section type).  */
+
+#define SHT_NULL      0     /* Section header table entry unused */
+#define SHT_PROGBITS      1     /* Program data */
+#define SHT_SYMTAB    2     /* Symbol table */
+#define SHT_STRTAB    3     /* String table */
+#define SHT_RELA      4     /* Relocation entries with addends */
+#define SHT_HASH      5     /* Symbol hash table */
+#define SHT_DYNAMIC   6     /* Dynamic linking information */
+#define SHT_NOTE      7     /* Notes */
+#define SHT_NOBITS    8     /* Program space with no data (bss) */
+#define SHT_REL       9     /* Relocation entries, no addends */
+#define SHT_SHLIB     10        /* Reserved */
+#define SHT_DYNSYM    11        /* Dynamic linker symbol table */
+#define SHT_INIT_ARRAY    14        /* Array of constructors */
+#define SHT_FINI_ARRAY    15        /* Array of destructors */
+#define SHT_PREINIT_ARRAY 16        /* Array of pre-constructors */
+#define SHT_GROUP     17        /* Section group */
+#define SHT_SYMTAB_SHNDX  18        /* Extended section indeces */
+#define SHT_NUM       19        /* Number of defined types.  */
+#define SHT_LOOS      0x60000000    /* Start OS-specific.  */
+#define SHT_GNU_ATTRIBUTES 0x6ffffff5   /* Object attributes.  */
+#define SHT_GNU_HASH      0x6ffffff6    /* GNU-style hash table.  */
+#define SHT_GNU_LIBLIST   0x6ffffff7    /* Prelink library list */
+#define SHT_CHECKSUM      0x6ffffff8    /* Checksum for DSO content.  */
+#define SHT_LOSUNW    0x6ffffffa    /* Sun-specific low bound.  */
+#define SHT_SUNW_move     0x6ffffffa
+#define SHT_SUNW_COMDAT   0x6ffffffb
+#define SHT_SUNW_syminfo  0x6ffffffc
+#define SHT_GNU_verdef    0x6ffffffd    /* Version definition section.  */
+#define SHT_GNU_verneed   0x6ffffffe    /* Version needs section.  */
+#define SHT_GNU_versym    0x6fffffff    /* Version symbol table.  */
+#define SHT_HISUNW    0x6fffffff    /* Sun-specific high bound.  */
+#define SHT_HIOS      0x6fffffff    /* End OS-specific type */
+#define SHT_LOPROC    0x70000000    /* Start of processor-specific */
+#define SHT_HIPROC    0x7fffffff    /* End of processor-specific */
+#define SHT_LOUSER    0x80000000    /* Start of application-specific */
+#define SHT_HIUSER    0x8fffffff    /* End of application-specific */
+
+/* Legal values for sh_flags (section flags).  */
+
+#define SHF_WRITE        (1 << 0)   /* Writable */
+#define SHF_ALLOC        (1 << 1)   /* Occupies memory during execution */
+#define SHF_EXECINSTR        (1 << 2)   /* Executable */
+#define SHF_MERGE        (1 << 4)   /* Might be merged */
+#define SHF_STRINGS      (1 << 5)   /* Contains nul-terminated strings */
+#define SHF_INFO_LINK        (1 << 6)   /* `sh_info' contains SHT index */
+#define SHF_LINK_ORDER       (1 << 7)   /* Preserve order after combining */
+#define SHF_OS_NONCONFORMING (1 << 8)   /* Non-standard OS specific handling
+                       required */
+#define SHF_GROUP        (1 << 9)   /* Section is member of a group.  */
+#define SHF_TLS          (1 << 10)  /* Section hold thread-local data.  */
+#define SHF_COMPRESSED       (1 << 11)  /* Section with compressed data. */
+#define SHF_MASKOS       0x0ff00000 /* OS-specific.  */
+#define SHF_MASKPROC         0xf0000000 /* Processor-specific */
+#define SHF_ORDERED      (1 << 30)  /* Special ordering requirement
+                       (Solaris).  */
+#define SHF_EXCLUDE      (1U << 31) /* Section is excluded unless
+                       referenced or allocated (Solaris).*/
+
+
+
+
+#define CODE_ADDRESS 0x1000
+#define MAX_CODE_SIZE 0x1000
+#define DATA_ADDRESS 0x100000
+#define MAX_DATA_SIZE 0x1000
+#define MAX_SECTIONS 16
+
+bool loadElf(char* code, size_t* codeSize, char* data, char* raw, size_t size);
+
+
+#endif

--- a/testbench/elf.h
+++ b/testbench/elf.h
@@ -261,7 +261,6 @@ typedef struct
 #define MAX_DATA_SIZE 0x1000
 #define MAX_SECTIONS 16
 
-bool loadElf(char* code, size_t* codeSize, char* data, char* raw, size_t size);
-
+bool loadElf(char* code, size_t* codeSize, char* data, size_t* dataSize, char* raw, size_t size);
 
 #endif

--- a/testbench/elf.h
+++ b/testbench/elf.h
@@ -153,6 +153,106 @@ typedef struct
                        referenced or allocated (Solaris).*/
 
 
+/* Program segment header.  */
+
+typedef struct
+{
+  Elf32_Word    p_type;         /* Segment type */
+  Elf32_Off p_offset;       /* Segment file offset */
+  Elf32_Addr    p_vaddr;        /* Segment virtual address */
+  Elf32_Addr    p_paddr;        /* Segment physical address */
+  Elf32_Word    p_filesz;       /* Segment size in file */
+  Elf32_Word    p_memsz;        /* Segment size in memory */
+  Elf32_Word    p_flags;        /* Segment flags */
+  Elf32_Word    p_align;        /* Segment alignment */
+} Elf32_Phdr;
+
+/* Special value for e_phnum.  This indicates that the real number of
+   program headers is too large to fit into e_phnum.  Instead the real
+   value is in the field sh_info of section 0.  */
+
+#define PN_XNUM     0xffff
+
+/* Legal values for p_type (segment type).  */
+
+#define PT_NULL     0       /* Program header table entry unused */
+#define PT_LOAD     1       /* Loadable program segment */
+#define PT_DYNAMIC  2       /* Dynamic linking information */
+#define PT_INTERP   3       /* Program interpreter */
+#define PT_NOTE     4       /* Auxiliary information */
+#define PT_SHLIB    5       /* Reserved */
+#define PT_PHDR     6       /* Entry for header table itself */
+#define PT_TLS      7       /* Thread-local storage segment */
+#define PT_NUM      8       /* Number of defined types */
+#define PT_LOOS     0x60000000  /* Start of OS-specific */
+#define PT_GNU_EH_FRAME 0x6474e550  /* GCC .eh_frame_hdr segment */
+#define PT_GNU_STACK    0x6474e551  /* Indicates stack executability */
+#define PT_GNU_RELRO    0x6474e552  /* Read-only after relocation */
+#define PT_LOSUNW   0x6ffffffa
+#define PT_SUNWBSS  0x6ffffffa  /* Sun Specific segment */
+#define PT_SUNWSTACK    0x6ffffffb  /* Stack segment */
+#define PT_HISUNW   0x6fffffff
+#define PT_HIOS     0x6fffffff  /* End of OS-specific */
+#define PT_LOPROC   0x70000000  /* Start of processor-specific */
+#define PT_HIPROC   0x7fffffff  /* End of processor-specific */
+
+/* Legal values for p_flags (segment flags).  */
+
+#define PF_X        (1 << 0)    /* Segment is executable */
+#define PF_W        (1 << 1)    /* Segment is writable */
+#define PF_R        (1 << 2)    /* Segment is readable */
+#define PF_MASKOS   0x0ff00000  /* OS-specific */
+#define PF_MASKPROC 0xf0000000  /* Processor-specific */
+
+/* Legal values for note segment descriptor types for core files. */
+
+#define NT_PRSTATUS 1       /* Contains copy of prstatus struct */
+#define NT_FPREGSET 2       /* Contains copy of fpregset struct */
+#define NT_PRPSINFO 3       /* Contains copy of prpsinfo struct */
+#define NT_PRXREG   4       /* Contains copy of prxregset struct */
+#define NT_TASKSTRUCT   4       /* Contains copy of task structure */
+#define NT_PLATFORM 5       /* String from sysinfo(SI_PLATFORM) */
+#define NT_AUXV     6       /* Contains copy of auxv array */
+#define NT_GWINDOWS 7       /* Contains copy of gwindows struct */
+#define NT_ASRS     8       /* Contains copy of asrset struct */
+#define NT_PSTATUS  10      /* Contains copy of pstatus struct */
+#define NT_PSINFO   13      /* Contains copy of psinfo struct */
+#define NT_PRCRED   14      /* Contains copy of prcred struct */
+#define NT_UTSNAME  15      /* Contains copy of utsname struct */
+#define NT_LWPSTATUS    16      /* Contains copy of lwpstatus struct */
+#define NT_LWPSINFO 17      /* Contains copy of lwpinfo struct */
+#define NT_PRFPXREG 20      /* Contains copy of fprxregset struct */
+#define NT_SIGINFO  0x53494749  /* Contains copy of siginfo_t,
+                       size might increase */
+#define NT_FILE     0x46494c45  /* Contains information about mapped
+                       files */
+#define NT_PRXFPREG 0x46e62b7f  /* Contains copy of user_fxsr_struct */
+#define NT_PPC_VMX  0x100       /* PowerPC Altivec/VMX registers */
+#define NT_PPC_SPE  0x101       /* PowerPC SPE/EVR registers */
+#define NT_PPC_VSX  0x102       /* PowerPC VSX registers */
+#define NT_386_TLS  0x200       /* i386 TLS slots (struct user_desc) */
+#define NT_386_IOPERM   0x201       /* x86 io permission bitmap (1=deny) */
+#define NT_X86_XSTATE   0x202       /* x86 extended state using xsave */
+#define NT_S390_HIGH_GPRS   0x300   /* s390 upper register halves */
+#define NT_S390_TIMER   0x301       /* s390 timer register */
+#define NT_S390_TODCMP  0x302       /* s390 TOD clock comparator register */
+#define NT_S390_TODPREG 0x303       /* s390 TOD programmable register */
+#define NT_S390_CTRS    0x304       /* s390 control registers */
+#define NT_S390_PREFIX  0x305       /* s390 prefix register */
+#define NT_S390_LAST_BREAK  0x306   /* s390 breaking event address */
+#define NT_S390_SYSTEM_CALL 0x307   /* s390 system call restart data */
+#define NT_S390_TDB 0x308       /* s390 transaction diagnostic block */
+#define NT_ARM_VFP  0x400       /* ARM VFP/NEON registers */
+#define NT_ARM_TLS  0x401       /* ARM TLS register */
+#define NT_ARM_HW_BREAK 0x402       /* ARM hardware breakpoint registers */
+#define NT_ARM_HW_WATCH 0x403       /* ARM hardware watchpoint registers */
+
+/* Legal values for the note segment descriptor types for object files.  */
+
+#define NT_VERSION  1       /* Contains a version string.  */
+
+
+
 
 
 #define CODE_ADDRESS 0x1000

--- a/testbench/elfloader.cpp
+++ b/testbench/elfloader.cpp
@@ -12,22 +12,17 @@ bool validateElf(Elf32_Ehdr* hdr){
     //check if valid ELF file
 
     if(hdr->e_ident[EI_MAG0] != ELFMAG0) {
-        cout << "mmmm1" << endl;
         return false;
     }
     if(hdr->e_ident[EI_MAG1] != ELFMAG1) {
-        cout << "mmmm2" << endl;
         return false;
     }
     if(hdr->e_ident[EI_MAG2] != ELFMAG2) {
-        cout << "mmmm3" << endl;
         return false;
     }
     if(hdr->e_ident[EI_MAG3] != ELFMAG3) {
-        cout << "mmmm4" << endl;
         return false;
     }
-    cout << "magic valid" << endl;
     //now check if valid to be loaded into Qtum's x86 VM
     //if(!elf_check_file(hdr)) {
     //    return false;
@@ -69,9 +64,11 @@ bool loadElf(char* code, size_t* codeSize, char* data, size_t* dataSize, char* r
         return false;
     }
 
-    for(int i=0;i<MAX_SECTIONS;i++){
-        if(hdr->e_phoff + (hdr->e_phentsize * i) + sizeof(Elf32_Phdr) < size){
+    for(int i=0;i<hdr->e_phnum;i++){
+        if(hdr->e_phoff + (hdr->e_phentsize * i) + sizeof(Elf32_Phdr) > size){
             cout << "Not enough room in file to load program header #" << i << endl;
+            cout << "size: 0x" << hex << size << ", offset: 0x" << hex << hdr->e_phoff << 
+                " sizeof header: 0x" << hex << sizeof(Elf32_Phdr) << " phentsize: 0x" << hex << hdr->e_phentsize << endl; 
             return false;
         }
         Elf32_Phdr *phdr = (Elf32_Phdr*) &raw[hdr->e_phoff + (hdr->e_phentsize * i)];

--- a/testbench/elfloader.cpp
+++ b/testbench/elfloader.cpp
@@ -1,0 +1,118 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "elf.h"
+
+using namespace std;
+
+
+bool validateElf(Elf32_Ehdr* hdr){
+    //check if valid ELF file
+    if(hdr->e_ident[EI_MAG0] != ELFMAG0) {
+        return false;
+    }
+    if(hdr->e_ident[EI_MAG1] != ELFMAG1) {
+        return false;
+    }
+    if(hdr->e_ident[EI_MAG2] != ELFMAG2) {
+        return false;
+    }
+    if(hdr->e_ident[EI_MAG3] != ELFMAG3) {
+        return false;
+    }
+    //now check if valid to be loaded into Qtum's x86 VM
+    //if(!elf_check_file(hdr)) {
+    //    return false;
+    //}
+    if(hdr->e_ident[EI_CLASS] != ELFCLASS32) {
+        return false;
+    }
+    if(hdr->e_ident[EI_DATA] != ELFDATA2LSB) {
+        return false;
+    }
+    if(hdr->e_machine != EM_386) {
+        return false;
+    }
+    if(hdr->e_ident[EI_VERSION] != EV_CURRENT) {
+        return false;
+    }
+    if(hdr->e_type != ET_EXEC) {
+        return false;
+    }
+    //qtum rules:
+    if(hdr->e_entry != CODE_ADDRESS){
+        return false;
+    }
+    return true;
+}
+
+
+
+//code is memory buffer available for readonly data
+//data is memory buffer available for readwrite data
+//code is 0x1000, data is 0x100000
+bool loadElf(char* code, size_t* codeSize, char* data, char* raw, size_t size){
+    if(size < sizeof(Elf32_Ehdr)){
+        return false;
+    }
+
+    Elf32_Ehdr *hdr = (Elf32_Ehdr*) raw;
+    if(!validateElf(hdr)){
+        return false;
+    }
+
+    bool codeProcessed;
+    for(int i=1;i<MAX_SECTIONS;i++){ //1st section is undefined
+        if(hdr->e_shoff + (hdr->e_shentsize * i) + sizeof(Elf32_Shdr) < size){
+            return false;
+        }
+        Elf32_Shdr *section = (Elf32_Shdr*) &raw[hdr->e_shoff + (hdr->e_shentsize * i)];
+
+        if(section->sh_type == SHT_PROGBITS && 
+            (section->sh_flags & SHF_EXECINSTR && section->sh_flags & SHF_ALLOC)){
+            //.text and readonly bits
+            if(section->sh_addr != CODE_ADDRESS || codeProcessed){
+                //Only allow 1 section to load into code address
+                return false;
+            }
+            if(section->sh_addr + section->sh_size > CODE_ADDRESS + MAX_CODE_SIZE){
+                //error if trying to load code outside of code area
+                return false;
+            }
+            if(section->sh_offset + section->sh_size > size){
+                return false;
+            }
+            memcpy(code, &raw[section->sh_offset], section->sh_size);
+            *codeSize = section->sh_size;
+            codeProcessed=true;
+        }else if(section->sh_type == SHT_PROGBITS && 
+            (section->sh_flags & SHF_WRITE && section->sh_flags & SHF_ALLOC)){
+            //.data and readwrite bits
+            if(section->sh_addr < DATA_ADDRESS || 
+                section->sh_addr + section->sh_size > DATA_ADDRESS + MAX_DATA_SIZE){
+                //error if trying to load data outside of data area
+                //TODO: we could allow for this to do allocation or something.. 
+                return false;
+            }
+            if(section->sh_offset + section->sh_size > size){
+                return false;
+            }
+            memcpy(&data[section->sh_addr], &raw[section->sh_offset], section->sh_size);
+        }else if(section->sh_type == SHT_NOBITS && 
+            (section->sh_flags & SHF_WRITE && section->sh_flags & SHF_ALLOC)){
+            //bss.. 
+            if(section->sh_addr < DATA_ADDRESS || 
+                section->sh_addr + section->sh_size > DATA_ADDRESS + MAX_DATA_SIZE){
+                //Even though we load no data, if this is triggered then .bss is 
+                //located in an area of memory that is not available, so error.
+                return false;
+            }
+            //anything to do here?
+        }else{
+            //ignore unknown sections
+        }
+    }
+    return true;
+}
+
+

--- a/testbench/elfloader.cpp
+++ b/testbench/elfloader.cpp
@@ -122,7 +122,7 @@ bool loadElf(char* code, size_t* codeSize, char* data, size_t* dataSize, char* r
         code[0] = 0xE9; //jmp rel32
         int32_t entry = hdr->e_entry;
         entry -= CODE_ADDRESS; //make a relative address to code[0]
-        entry -= 5; //account for size of JMP rel32 instruction
+        //entry -= 5; //account for size of JMP rel32 instruction
         if(entry < 0){
             cout << "Entry point is negative!" << endl;
             return false;

--- a/testbench/elfloader.cpp
+++ b/testbench/elfloader.cpp
@@ -114,7 +114,7 @@ bool loadElf(char* code, size_t* codeSize, char* data, size_t* dataSize, char* r
             cout << "Address: 0x" << hex << phdr->p_vaddr << ", Size: 0x" << hex << phdr->p_memsz << endl;
             return false;
         }
-        cout << "Loaded segment #" << i << "at address 0x" << hex << phdr->p_vaddr << " of size 0x" << hex << phdr->p_memsz << endl;
+        cout << "Loaded segment #" << i << " at address 0x" << hex << phdr->p_vaddr << " of size 0x" << hex << phdr->p_memsz << endl;
     }
     return true;
 }

--- a/testbench/linker.ld
+++ b/testbench/linker.ld
@@ -9,27 +9,32 @@ MEMORY
 }
 SECTIONS
 {
-  .text phys : AT(phys) {
+  . = ALIGN(4);
+  .text : AT(phys) ALIGN(4) {
+    . = ALIGN(4);
     code = .;
     *(.text.start);
     *(.text*)
     *(.rodata)
     . = ALIGN(4);
-  } > coderom
+  }
   __text_end=.;
-  .data : AT(phys + (data - code))
+  . = ALIGN(4);
+  .data : AT(scratch)
   {
+    . = ALIGN(4);
     data = .;
     *(.data)
     . = ALIGN(4);
-  } > coderom
+  } > scratchram
   __data_end=.;
   __binary_end = .;
-  .bss : AT(scratch)
+  .bss : AT(scratch + (bss - data))
   {
     bss = .;
     *(.bss)
     . = ALIGN(4);
   } > scratchram
 }
+
 

--- a/testbench/linker.ld
+++ b/testbench/linker.ld
@@ -1,6 +1,6 @@
 OUTPUT_FORMAT("elf32-i386")
 ENTRY(start)
-phys = 0x1000;
+phys = 0x1008;
 scratch = 0x100000;
 MEMORY
 {

--- a/testbench/linker.ld
+++ b/testbench/linker.ld
@@ -1,4 +1,4 @@
-OUTPUT_FORMAT("binary")
+OUTPUT_FORMAT("elf32-i386")
 ENTRY(start)
 phys = 0x1000;
 scratch = 0x100000;

--- a/testbench/test.asm
+++ b/testbench/test.asm
@@ -28,8 +28,9 @@
 
 CPU i386
 BITS 32
-SECTION .text progbits alloc exec nowrite address=1000
-;ORG 0x1000
+SECTION .text progbits alloc exec nowrite align=1
+GLOBAL start
+
 
 start:
 mov eax, 0 
@@ -43,25 +44,15 @@ mov eax, ebx
 out 0xF3, al ;dump memory API call
 
 out 0xF0, ax
+mov eax, [foo]
+out 0xF0, eax
 cli
 hlt
 
-rep lodsw
-
-;add 10 bytes of padding for reasons
-nop
-nop
-nop
-nop
-
-nop
-nop
-nop
-nop
-
-nop
-nop
-
+SECTION .data align=1
+GLOBAL foo
+foo: db 0x01
+dd 0x1032
 
 
 

--- a/testbench/test.asm
+++ b/testbench/test.asm
@@ -28,7 +28,8 @@
 
 CPU i386
 BITS 32
-ORG 0x1000
+SECTION .text progbits alloc exec nowrite address=1000
+;ORG 0x1000
 
 start:
 mov eax, 0 

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -278,8 +278,8 @@ int main(int argc, char* argv[]){
 	file.seekg(0, std::ios::end);
 	fileLength = (uint32_t) (((long)file.tellg()) - (long) fileLength);
 	file.seekg(0, std::ios::beg);
-	file.read(filedata, size_memory);
-
+	file.read(filedata, maxSize);
+	cout << "first byte: 0x" << hex << (int) filedata[0] << ", file size: " << fileLength << endl;
 	size_t codesize;
 	size_t datasize;
 	if(!loadElf(coderom.GetMemory(), &codesize, scratch.GetMemory(), &datasize, filedata, fileLength)){

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -250,7 +250,7 @@ int main(int argc, char* argv[]){
 	RAMemory stack(0x1000, "stack");
 	scratchMem = &scratch;
 	
-	Memory.Add(0, 0xFFF, &config);
+	Memory.Add(0x5, 0xFFF, &config);
 	Memory.Add(0x1000, 0xFFFFF, &coderom);
 	Memory.Add(0x100000, 0x1FFFFF, &scratch);
 	Memory.Add(0x200000, 0x201000, &stack);

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -241,11 +241,13 @@ int main(int argc, char* argv[]){
 	ROMemory coderom(0x1000, "code");
 	RAMemory config(0x1000, "config");
 	RAMemory scratch(0x100000, "scratch");
+	RAMemory stack(0x1000, "stack");
 	scratchMem = &scratch;
 	
 	Memory.Add(0, 0xFFF, &config);
 	Memory.Add(0x1000, 0xFFFFF, &coderom);
 	Memory.Add(0x100000, 0x1FFFFF, &scratch);
+	Memory.Add(0x200000, 0x201000, &stack);
 
 	int maxSize=0x10000;
 	char* fileData=new char[maxSize];

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -278,10 +278,11 @@ int main(int argc, char* argv[]){
 	file.seekg(0, std::ios::end);
 	fileLength = (uint32_t) (((long)file.tellg()) - (long) fileLength);
 	file.seekg(0, std::ios::beg);
-	file.read(filedata,size_memory);
+	file.read(filedata, size_memory);
 
 	size_t codesize;
-	if(!loadElf(coderom.GetMemory(), &codesize, scratch.GetMemory(), filedata, fileLength)){
+	size_t datasize;
+	if(!loadElf(coderom.GetMemory(), &codesize, scratch.GetMemory(), &datasize, filedata, fileLength)){
 		cout << "error loading ELF" << endl;
 		return -1;
 	}

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -126,6 +126,7 @@ void WritePort(uint16_t port,uint32_t val){
 	functions to try out...*/
 	switch(port){
 		case 0: //print ascii char of val
+		cout << "printing.. "<< (int) val << endl;
 		cout << (char) val << flush;
 		break;
 		case 1: //print value of byte
@@ -224,6 +225,7 @@ void each_opcode(x86CPU *thiscpu){
 }
 
 bool singleStep=false;
+bool singleStepShort=false;
 
 int main(int argc, char* argv[]){
 	if(argc < 2){
@@ -233,6 +235,10 @@ int main(int argc, char* argv[]){
 	if(argc > 2){
 		if(strcmp(argv[2], "-singlestep") == 0){
 			singleStep = true;
+		}
+		if(strcmp(argv[2], "-singlestep-short") == 0){
+			singleStep = true;
+			singleStepShort=true;
 		}
 	}
 
@@ -310,8 +316,12 @@ int main(int argc, char* argv[]){
 			}else{
 				cpu->Exec(1);
 				cout <<"OPCODE: " << cpu->GetLastOpcodeName() << "; hex: 0x" << hex << cpu->GetLastOpcode() << endl;
-				cpu->DumpState(cout);
-				cout << "-------------------------------" << endl;
+				if(singleStepShort){
+					cout << "EIP: 0x" << cpu->GetLocation() << endl;
+				}else{
+					cpu->DumpState(cout);
+					cout << "-------------------------------" << endl;
+				}
 				if(int_cause){
 					int_cause=false;
 					cpu->Int(int_cause_number);

--- a/testbench/testbench.cpp
+++ b/testbench/testbench.cpp
@@ -276,6 +276,7 @@ int main(int argc, char* argv[]){
 
 	if(doElf){
 		//load ELF32 file
+		cout << "Found .elf file extension. Attempting to load ELF file" << endl;
 		size_t codesize;
 		size_t datasize;
 		if(!loadElf(coderom.GetMemory(), &codesize, scratch.GetMemory(), &datasize, fileData, fileLength)){
@@ -284,6 +285,7 @@ int main(int argc, char* argv[]){
 		}
 	}else{
 		//load BIN file (no option to load data with bin files)
+		cout << "Attempting to load BIN file. Warning: It is not possible to load data with this" << endl;
 		memcpy(coderom.GetMemory(), fileData, fileLength);
 	}
 

--- a/vm/modrm.cpp
+++ b/vm/modrm.cpp
@@ -48,10 +48,13 @@ uint32_t ModRM::GetRegD32(){ //This returns the register displacement value
             return this_cpu->regs32[EBX];
             break;
         case 4:
-            //TODO SIB
+            // SIB
             return 0;
             break;
         case 5: //immediate Displacement only, so no register displace..
+            if(modrm.mod != 0){
+                return this_cpu->regs32[EBP];
+            }
             return 0;
         case 6:
             return this_cpu->regs32[ESI];

--- a/vm/ops/flags.cpp
+++ b/vm/ops/flags.cpp
@@ -74,20 +74,21 @@ static bool jcc(int condition, volatile FLAGS &f){
 void x86CPU::op_jcc_rel8(){
     int cc = opbyte-0x70;
     uint8_t rel = ReadCode8(1);
-    eip+=2;
     if(jcc(cc, freg)){
         Jmp_near8(rel);
+    }else{
+        eip++;
     }
 }
 
 void x86CPU::op_jcc_relW(){
     int cc = opbyte-0x80;
     uint32_t rel = ReadCodeW(1);
-    eip+=OperandSize() + 1; //1 to move past current opcode
     if(jcc(cc, freg)){
         Jmp_nearW(rel);
+    }else{
+        eip+=OperandSize(); //1 to move past current opcode
     }
-    eip--;
 }
 
 

--- a/vm/ops/flags.cpp
+++ b/vm/ops/flags.cpp
@@ -75,7 +75,9 @@ void x86CPU::op_jcc_rel8(){
     int cc = opbyte-0x70;
     uint8_t rel = ReadCode8(1);
     if(jcc(cc, freg)){
+        eip += 2;
         Jmp_near8(rel);
+        eip--;
     }else{
         eip++;
     }
@@ -85,7 +87,9 @@ void x86CPU::op_jcc_relW(){
     int cc = opbyte-0x80;
     uint32_t rel = ReadCodeW(1);
     if(jcc(cc, freg)){
+        eip += OperandSize() + 1;
         Jmp_nearW(rel);
+        eip--;
     }else{
         eip+=OperandSize(); //1 to move past current opcode
     }

--- a/vm/ops/flow.cpp
+++ b/vm/ops/flow.cpp
@@ -35,12 +35,14 @@ using namespace std;
 
 void x86CPU::op_jmp_rel8(){
     uint8_t rel = ReadCode8(1);
+    eip += 2;
 	Jmp_near8(rel);
 	eip--;
 }
 
 void x86CPU::op_jmp_relW(){
     uint32_t rel = ReadCodeW(1);
+    eip += OperandSize() + 1;
 	//+ operand to move past immediate, and +1 to move past current opcode
     Jmp_nearW(rel);
     eip--;
@@ -69,6 +71,7 @@ void x86CPU::op_jmp_mF(ModRM &rm){
 void x86CPU::op_jcxzW_rel8(){
     uint8_t rel = ReadCode8(1);
 	if(Reg(ECX)==0){
+        eip++;
 		Jmp_near8(rel);
         eip--;
 	}else{
@@ -82,8 +85,8 @@ void x86CPU::op_jcxzW_rel8(){
 void x86CPU::op_call_relW(){
     uint32_t tmp = ReadCodeW(1);
 	//increment eip to move beyond relW and then +1 to increment past current opcode byte
-	//eip+=(OperandSize16 ? 2 : 4) + 1;
-	Push(eip + (OperandSize16 ? 2 : 4) + 1);
+	eip+=(OperandSize16 ? 2 : 4) + 1;
+	Push(eip); //+ (OperandSize16 ? 2 : 4) + 1);
 	Jmp_nearW(tmp);
     eip--;
 }

--- a/vm/ops/flow.cpp
+++ b/vm/ops/flow.cpp
@@ -35,7 +35,6 @@ using namespace std;
 
 void x86CPU::op_jmp_rel8(){
     uint8_t rel = ReadCode8(1);
-	eip+=2; //1 for current opcode and 1 for rel8 byte
 	Jmp_near8(rel);
 	eip--;
 }
@@ -43,7 +42,6 @@ void x86CPU::op_jmp_rel8(){
 void x86CPU::op_jmp_relW(){
     uint32_t rel = ReadCodeW(1);
 	//+ operand to move past immediate, and +1 to move past current opcode
-    eip+=OperandSize() + 1; //get to first byte of next opcode so jmp works right
     Jmp_nearW(rel);
     eip--;
 }
@@ -70,21 +68,24 @@ void x86CPU::op_jmp_mF(ModRM &rm){
 
 void x86CPU::op_jcxzW_rel8(){
     uint8_t rel = ReadCode8(1);
-	eip+=2; //relative jump should happen at the beginning of the next opcode
 	if(Reg(ECX)==0){
 		Jmp_near8(rel);
-	}
-    eip--; //counteract increment in Cycle()
+        eip--;
+	}else{
+        eip++; //relative jump should happen at the beginning of the next opcode
+    }
 }
 
 
 
 
 void x86CPU::op_call_relW(){
+    uint32_t tmp = ReadCodeW(1);
 	//increment eip to move beyond relW and then +1 to increment past current opcode byte
-	eip+=(OperandSize16 ? 2 : 4) + 1;
-	Push(eip);
-	Jmp_nearW(ImmW());
+	//eip+=(OperandSize16 ? 2 : 4) + 1;
+	Push(eip + (OperandSize16 ? 2 : 4) + 1);
+	Jmp_nearW(tmp);
+    eip--;
 }
 
 void x86CPU::op_retn(){ 

--- a/vm/ops/store.cpp
+++ b/vm/ops/store.cpp
@@ -327,14 +327,12 @@ void x86CPU::op_movsx_rW_rm8(){
     SetReg(rm.GetExtra(), SignExtend8to32(rm.ReadByte()));
 }
 
-    SetReg(DI,Pop());
-    SetReg(SI,Pop());
-    SetReg(BP,Pop());
-    SetReg(SP,Reg(SP)+ofs);
-    SetReg(BX,Pop());
-    SetReg(DX,Pop());
-    SetReg(CX,Pop());
-    SetReg(AX,Pop());
+void x86CPU::op_pushf(){
+    Push(freg.data);
+}
+
+void x86CPU::op_popf(){
+    freg.data = Pop();
 }
 
 };

--- a/vm/ops/store.cpp
+++ b/vm/ops/store.cpp
@@ -286,8 +286,15 @@ void x86CPU::op_movzx_r32_rmW(){
     regs32[rm.GetExtra()] = rm.ReadWord();
 }
 
+void x86CPU::op_leave(){
+    SetReg(ESP, Reg(EBP));
+    SetReg(EBP, Pop());
+}
 
-
+void x86CPU::op_movsx_rW_rm8(){
+    ModRM rm(this);
+    SetReg(rm.GetExtra(), SignExtend8to32(rm.ReadByte()));
+}
 
 };
 

--- a/vm/x86lib.cpp
+++ b/vm/x86lib.cpp
@@ -484,7 +484,7 @@ void x86CPU::InitOpcodes(){
     op(0xC6, op_mov_rm8_imm8);
     op(0xC7, op_mov_rmW_immW);
     //op(0xC8, op_enter); //186
-    //op(0xC9, op_leave); //186
+    op(0xC9, op_leave); //186
     op(0xCA, op_retf_imm16); //???
     op(0xCB, op_retf);
     op(0xCC, op_int3);
@@ -549,6 +549,9 @@ void x86CPU::InitOpcodes(){
 
 
     //note: All 0x0F "extended" opcodes begin at 286+, so compatibility will only be noted if above 286 level
+
+    
+    opx(0xBE, op_movsx_rW_rm8); //386
 /* commenting all these out for now
 
     opxg(0x00, 0, op_naG); //sldt
@@ -633,7 +636,6 @@ void x86CPU::InitOpcodes(){
     opx(0xBB, op_btc_rmW_rW); //386
     opx(0xBC, op_bsf_rW_rmW); //386
     opx(0xBD, op_bsr_rW_rmW); //386
-    opx(0xBE, op_movsx_rW_rm8); //386
     opx(0xBF, op_movsx_rW_rm16); //386
     opx(0xC0, op_xadd_rm8_r8); //486
     opx(0xC1, op_xadd_rmW_rW); //486

--- a/vm/x86lib.cpp
+++ b/vm/x86lib.cpp
@@ -74,7 +74,7 @@ void x86CPU::Reset(){
 	eip=0x1000;
 	seg[cCS]=0;
 	freg.data=0;
-    regs32[ESP] = 0x1FF000; //set stack to reasonable address for Qtum
+    regs32[ESP] = 0x200800; //set stack to reasonable address for Qtum
 	string_compares=0;
 	int_pending=0;
 	cli_count=0;


### PR DESCRIPTION
This adds support for loading ELF files. You can make it process a file as ELF by making the file extension ".elf". You can use the toolchain project to compile C programs easily for x86Lib now, but there are too many opcode bugs to do much useful work at this point. 