### PR TITLE
Bug fixes in SetReg8, op_lahf, op_sahf and jcc

### DIFF
--- a/include/x86lib.h
+++ b/include/x86lib.h
@@ -678,7 +678,7 @@ class x86CPU{
             regs32[which] = (regs32[which] & 0xFFFFFF00) | val;
         }else{
             //4-7 is high bytes; ah, ch, dh, bh
-            regs32[which] = (regs32[which - 4] & 0xFFFF00FF) | (val << 8);
+            regs32[which - 4] = (regs32[which - 4] & 0xFFFF00FF) | (val << 8);
         }
     }
     inline void SetReg16(int which, uint16_t val){

--- a/vm/ops/flags.cpp
+++ b/vm/ops/flags.cpp
@@ -65,7 +65,7 @@ static bool jcc(int condition, volatile FLAGS &f){
         case 14:
             return (f.bits.sf!=f.bits.of) | f.bits.zf;
         case 15:
-            return (f.bits.sf==f.bits.of) & f.bits.zf;
+            return (f.bits.sf==f.bits.of) & !f.bits.zf;
         default:
             throw new CpuPanic_excp("This code should not be reached", 0xFFFF);
     }

--- a/vm/ops/flags.cpp
+++ b/vm/ops/flags.cpp
@@ -126,10 +126,10 @@ void x86CPU::op_cmc(){
 }
 
 void x86CPU::op_lahf(){
-	SetReg8(AL, freg.data & 0xFF);
+	SetReg8(AH, freg.data & 0xFF);
 }
 void x86CPU::op_sahf(){
-    freg.data = (freg.data & 0xFFFFFF00) | Reg8(AL);
+    freg.data = (freg.data & 0xFFFFFF00) | Reg8(AH);
 }
 
 


### PR DESCRIPTION
x86Lib.h
SetReg8: Wrong register in the case of ah, ch, dh, bh

flags.cpp
static bool jcc(int condition, volatile FLAGS &f)
zf should be 0 for the boolean expression to evaluate to true for condition = 15.
See JNLE on http://www.ousob.com/ng/iapx86/ng10482.php

op_lahf and op_sahf
Should operate on AH not AL.