### PR TITLE
fix the warning during `make test` for macOS.

### DIFF
--- a/tests/mov_tests.cpp
+++ b/tests/mov_tests.cpp
@@ -117,11 +117,11 @@ TEST_CASE("lea", "[lea]") {
     INFO("16bit lea");
     test.Apply(check);
     test.Run("o16 a16 lea ax, [bx + si + 2]", 1);
-    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
+    REQUIRE((int)(test.Check().Reg32(EAX) == (0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2))));
 
     test.Apply(check);
     test.Run("o16 a16 lea ax, [bx + si + 2]", 1);
-    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
+    REQUIRE((int)(test.Check().Reg32(EAX) == (0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2))));
 
     INFO("mixed lea");
     test.Apply(check);
@@ -130,7 +130,7 @@ TEST_CASE("lea", "[lea]") {
 
     test.Apply(check);
     test.Run("o16 a32 lea ax, [ebx - 50]", 1);
-    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS - 50)));
+    REQUIRE((int)(test.Check().Reg32(EAX) == (0xFFFF0000 | (SCRATCH_ADDRESS - 50))));
 
     INFO("big lea");
     test.Apply(check);
@@ -143,7 +143,7 @@ TEST_CASE("lea", "[lea]") {
 
     test.Apply(check);
     test.Run("a16 lea eax, [bx + si + 0x1234]", 1);
-    REQUIRE((int)(test.Check().Reg32(EAX) == (SCRATCH_ADDRESS + 10 + 0x1234) & 0xFFFF));
+    REQUIRE((int)(test.Check().Reg32(EAX) == ((SCRATCH_ADDRESS + 10 + 0x1234) & 0xFFFF)));
 }
 
 TEST_CASE("mov_axW_mW", "[mov]") {


### PR DESCRIPTION
There are 4 warnings during `make test` for macOS, all about the test cases in mov_tests.cpp.

c++ -Wall -fPIC -g -O0 -DX86LIB_BUILD -I./include -fexceptions -std=c++11 -c tests/mov_tests.cpp -o tests/mov_tests.o
tests/mov_tests.cpp:120:57: warning: | has lower precedence than ==; == will be evaluated first [-Wparentheses]
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:120:57: note: place parentheses around the '==' expression to silence this warning
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:120:57: note: place parentheses around the | expression to evaluate it first
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:124:57: warning: | has lower precedence than ==; == will be evaluated first [-Wparentheses]
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:124:57: note: place parentheses around the '==' expression to silence this warning
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:124:57: note: place parentheses around the | expression to evaluate it first
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS + 10 + 2)));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:133:57: warning: | has lower precedence than ==; == will be evaluated first [-Wparentheses]
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS - 50)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:133:57: note: place parentheses around the '==' expression to silence this warning
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS - 50)));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                                                                                         ^~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:133:57: note: place parentheses around the | expression to evaluate it first
    REQUIRE((int)(test.Check().Reg32(EAX) == 0xFFFF0000 | (SCRATCH_ADDRESS - 50)));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:146:78: warning: & has lower precedence than ==; == will be evaluated first [-Wparentheses]
    REQUIRE((int)(test.Check().Reg32(EAX) == (SCRATCH_ADDRESS + 10 + 0x1234) & 0xFFFF));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:146:78: note: place parentheses around the '==' expression to silence this warning
    REQUIRE((int)(test.Check().Reg32(EAX) == (SCRATCH_ADDRESS + 10 + 0x1234) & 0xFFFF));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
tests/mov_tests.cpp:146:78: note: place parentheses around the & expression to evaluate it first
    REQUIRE((int)(test.Check().Reg32(EAX) == (SCRATCH_ADDRESS + 10 + 0x1234) & 0xFFFF));
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
tests/catch.hpp:11809:90: note: expanded from macro 'REQUIRE'
#define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
tests/catch.hpp:1448:60: note: expanded from macro 'INTERNAL_CATCH_TEST'
    } while( Catch::isTrue( false && static_cast<bool>( !!(__VA_ARGS__) ) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
                                                           ^~~~~~~~~~~
4 warnings generated.